### PR TITLE
Specify correct chart name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It also has a few other of our favorite services:
     `settings.yaml`:
   - Set up SSL for the Controller Ingress (see below)
   - Add the Alea Helm repo: `helm repo add alea https://storage.googleapis.com/alea-charts`
-  - Install Alea in the `services` namespace, using your `settings.yaml`: `helm install alea --namespace=services --name alea --values=settings.yaml`
+  - Install Alea in the `services` namespace, using your `settings.yaml`: `helm install alea/alea --namespace=services --name alea --values=settings.yaml`
   - Wait for the stack to be provisioned, then get the IP for the controller ingress: `kubectl -n services get ing`. Create an A-record for you DNS to point to whatever you set for the `controller.domain` setting to be.
   - Check out the **Usage section** below to start using the services in your Deis apps!
 


### PR DESCRIPTION
Hi! The README had the wrong chart name specified for the install; needs to be `alea/alea`.

```
$ helm search                                            
NAME                        VERSION DESCRIPTION
alea/alea                   0.1.0   A Helm chart for Backing Services for your Deis...
kubernetes-charts/drupal    0.3.5   One of the most versatile open source content m...
kubernetes-charts/jenkins   0.1.1   A Jenkins Helm chart for Kubernetes.
kubernetes-charts/mariadb   0.5.2   Chart for MariaDB
kubernetes-charts/mysql     0.1.2   Chart for MySQL
kubernetes-charts/redis     0.4.0   Chart for Redis
kubernetes-charts/redmine   0.3.4   A flexible project management web application.
kubernetes-charts/spartakus 1.0.0   A Spartakus Helm chart for Kubernetes. Spartaku...
kubernetes-charts/wordpress 0.3.2   Web publishing platform for building blogs and ...
```
